### PR TITLE
fix very small dSquared bug

### DIFF
--- a/IterativeStatsWithWindow.js
+++ b/IterativeStatsWithWindow.js
@@ -64,7 +64,9 @@ class RunningStatsCalculator {
             const newDSquared = this._dSquared + dSquaredIncrement
 
             this._mean = newMean
-            this._dSquared = newDSquared
+           
+            this._dSquared = (Math.abs(newDSquared) < 0.000_000_000_001)? 0: newDSquared
+            
         }
     }
 


### PR DESCRIPTION
fails with test with buffersize 6, input samples [1,2,3,3,3,4,4,4,4,5,5,5,5,5,6,6,6,6,6,6] on the last value due to performing Math.sqrt on "uncorrected" dSquared values.